### PR TITLE
v.0.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.preferCSharpExtension": true
+}

--- a/README.md
+++ b/README.md
@@ -1,17 +1,33 @@
-# RealBuyParts
+# RealShop
 
 This mod is created to prevent the possibility of buying body parts for cars older than 2000 in the store. To obtain the necessary parts for the car you are working on, you will have to search for all the body elements in a junkyard, barns, or auctions. This mod makes the game a little more challenging and interesting. Also I hope that it will slightly change the gaming experience, making it a bit more challenging and engaging. I hope you will like it.
 
 ## Features include:
 
-You will need to search for the necessary parts for old cars and restore them; it is no longer possible to buy new parts for retro or old cars.
+**IMPORTANT AND RECOMMENDED! This mod should be used only when you have unlocked the entire branch for repairing parts and have purchased the necessary machines for repairing body and other parts.
 
-## How install: 
+Features include:
+
+- You will need to search for the necessary parts for old cars and restore them; it is no longer possible to buy new parts for retro or old cars.
+- Now junkyards, barns, and auctions take on a different meaning.
+- Now all body and interior parts can be repaired.
+- Now you can repair generic parts from all non-default manufacturers.
+- Added a configuration file where you can:
+           - Change the year for cars that will not appear in the shop.
+           - Change the binding key to enable or disable the mod.
+           - Add or remove specific brands from the list that won't appear in the shop.
+
+
+Important! Many parts in the shop will be unavailable. Now, junkyard visits have become a necessity. Non-default items won't be found in the shop, but you can find them in the barn, at auctions, or in the junkyard, and then repair them.
+
+Realism is getting closer, enjoy! :-)
+
+## How install:
 1. Download realshop.dll
 2. Download and install [MelonLoader](https://melonwiki.xyz/#/?id=requirements) ----> **!!!!   Only 0.5.7 VERSION**
 3. Copy the dll file to the **"Car Mechanic Simulator 2021\Mods"**
 
-## 
+##
 In the plans, I will remove engines, tires, and other items for old and retro cars from the store. Now junkyards, barns, and auctions take on a different meaning.
 
 ## Before

--- a/RealShop/Config.cs
+++ b/RealShop/Config.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace RealShop
 {
@@ -11,18 +12,56 @@ namespace RealShop
     {
         public const string ModName = "RealShop";
 
+        public static string[] Brands = { "trando", "voiz", "fierte", "shushutri", "bardogh" };
+
+        public static string[] TargetRepairParts = { "mirror", "window", "seat", "taillight", "pasek", "lancuch",
+            "srodkowy", "katalizator", "koncowy", "rura", "slizg", "filtr", "inverter", "wheel", "turbo", "kable", "challenger",
+            "washer", "reservoir", "srodkowy", "bak", "rolka", "walka", "pasek", "poczatkowy", "charging", "cewka", "tlumik", "wzdluzny"};
+        public static int[] RepairCost = {150, 250, 400};
+
         private const string ConfigCategoryName = "MainSection";
+        private const string ConfigRepairSection = "RepairSection";
 
         private readonly MelonPreferences_Category _config;
+        private readonly MelonPreferences_Category _repair;
+        private readonly MelonPreferences_Entry<KeyCode> _isEnableSwitchModeBindKey;
+        private readonly MelonPreferences_Entry<KeyCode> _printStackBindKey;
+        private readonly MelonPreferences_Entry<KeyCode> _repairBindKey;
+        private readonly MelonPreferences_Entry<bool> _isShowDebugInfo;
         private readonly MelonPreferences_Entry<int> _removeCarsOlderThanYear;
+        private readonly MelonPreferences_Entry<bool> _isEnableBrandFilter;
+        private readonly MelonPreferences_Entry<string[]> _brandsEntry;
+        private readonly MelonPreferences_Entry<string[]> _repairParts;
+        private readonly MelonPreferences_Entry<int[]> _repairCost;
 
+        public KeyCode IsEnableSwitchMode => _isEnableSwitchModeBindKey.Value;
+        public KeyCode PrintStack => _printStackBindKey.Value;
+        public KeyCode Repair => _repairBindKey.Value;
+        public bool IsShowDebugInfo => _isShowDebugInfo.Value;
         public int RemoveCarsOlderThanYear => _removeCarsOlderThanYear.Value;
+        public string[] PartBrands => _brandsEntry.Value;
+        public string[] RepairParts => _repairParts.Value;
+        public int[] ListRepairCost => _repairCost.Value;
+        public bool IsEnableBrandFilter => _isEnableBrandFilter.Value;
+
         public Config()
         {
             _config = MelonPreferences.CreateCategory(ConfigCategoryName);
             _config.SetFilePath("Mods/RealShop.cfg");
 
+            _isEnableSwitchModeBindKey = _config.CreateEntry(nameof(IsEnableSwitchMode), KeyCode.F9);
+
+            _isShowDebugInfo = _config.CreateEntry(nameof(IsShowDebugInfo), false);
             _removeCarsOlderThanYear = _config.CreateEntry(nameof(RemoveCarsOlderThanYear), 2000);
+            _isEnableBrandFilter = _config.CreateEntry(nameof(IsEnableBrandFilter), true);
+            _brandsEntry = _config.CreateEntry(nameof(PartBrands), Brands);
+
+            _repair = MelonPreferences.CreateCategory(ConfigRepairSection);
+            _repair.SetFilePath("Mods/RealShop.cfg");
+
+            _repairBindKey = _repair.CreateEntry(nameof(Repair), KeyCode.F8);
+            _repairParts = _repair.CreateEntry(nameof(RepairParts), TargetRepairParts);
+            _repairCost = _repair.CreateEntry(nameof(ListRepairCost), RepairCost);
         }
 
         public void Reload()

--- a/RealShop/Config.cs
+++ b/RealShop/Config.cs
@@ -1,0 +1,34 @@
+﻿using MelonLoader;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RealShop
+{
+    public class Config
+    {
+        public const string ModName = "RealShop";
+
+        private const string ConfigCategoryName = "MainSection";
+
+        private readonly MelonPreferences_Category _config;
+        private readonly MelonPreferences_Entry<int> _removeCarsOlderThanYear;
+
+        public int RemoveCarsOlderThanYear => _removeCarsOlderThanYear.Value;
+        public Config()
+        {
+            _config = MelonPreferences.CreateCategory(ConfigCategoryName);
+            _config.SetFilePath("Mods/RealShop.cfg");
+
+            _removeCarsOlderThanYear = _config.CreateEntry(nameof(RemoveCarsOlderThanYear), 2000);
+        }
+
+        public void Reload()
+        {
+            _config.LoadFromFile();
+
+        }
+    }
+}

--- a/RealShop/Helpers.cs
+++ b/RealShop/Helpers.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace RealShop
 {
@@ -17,6 +19,50 @@ namespace RealShop
             {
                 return -1;
             }
+        }
+
+        public static bool IsBrandExist(string brand)
+        {
+            foreach (string name in Config.Brands)
+            {
+                if (brand.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool CheckForSubstrings(string input, string[] targets)
+        {
+            return targets.Any(target => input.Contains(target));
+        }
+
+        public static string ToPrettyString(Item item)
+        {
+            if (item == null) return "";
+
+            return ($"(Item) ID: {item.ID}, UID: {item.UID}, Condition: {item.Condition}, Dent: {item.Dent}, " +
+                    $"Quality: {item.Quality}, IsExamined: {item.IsExamined}, RepairAmount: {item.RepairAmount}, " +
+                    $"WashFactor: {item.WashFactor}, OutsideRustEnabled: {item.OutsideRustEnabled}, Livery: {item.Livery}, " +
+                    $"LiveryStrength: {item.LiveryStrength}, NormalID: {item.NormalID}, ConditionToShow: {item.ConditionToShow}," +
+                    $"LPData: {item.LPData}");
+        }
+
+        public static string ToPrettyString(GroupItem groupItem)
+        {
+            if (groupItem == null) return "null";
+
+            return ($"(GroupItem) ID: {groupItem.ID}, UID: {groupItem.UID}, " +
+                            $"Condition: {groupItem.GetCondition()}, ConditionToShow: {groupItem.GetConditionToShow()}, " +
+                            $"Size: {groupItem.Size}, IsNormalGroup: {groupItem.IsNormalGroup}");
+        }
+
+        public static string ToPrettyString(BaseItem baseItem)
+        {
+            if (baseItem == null) return "null";
+            return ($"(BaseItem) ID: {baseItem.ID}, UID: {baseItem.UID}, " +
+                            $"Condition: {baseItem.GetCondition()}, ConditionToShow: {baseItem.GetConditionToShow()}");
         }
     }
 }

--- a/RealShop/Properties/AssemblyInfo.cs
+++ b/RealShop/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using RealShop;
 
 [assembly: Guid("386af579-e4eb-41ea-8bac-021fe322abf9")]
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]
 
-[assembly: MelonInfo(typeof(RealParts), "RealShop", "0.1", "https://microup.ru")]
+[assembly: MelonInfo(typeof(RealParts), "RealShop", "0.2", "https://microup.ru")]
 [assembly: MelonGame("Red Dot Games", "Car Mechanic Simulator 2021")]

--- a/RealShop/RealShop.cs
+++ b/RealShop/RealShop.cs
@@ -7,10 +7,15 @@ namespace RealShop
 {
     public class RealParts : MelonMod
     {
+
+        private Config _config;
+
         [Obsolete]
         public override void OnApplicationStart()
         {
             MelonLogger.Msg("initializing...");
+            _config = new Config();
+            _config.Reload();
         }
 
         public override void OnUpdate()
@@ -28,7 +33,7 @@ namespace RealShop
                         GameObject ShowroomCarObj = ShowroomCarItem21Shop.gameObject;
                         var carName = ShowroomCarItem21Shop.Find("CarName").GetComponent<Text>();
                         var carYear = Helpers.GetYearFromString(carName.text);
-                        if (carYear < 2000)
+                        if (carYear < _config.RemoveCarsOlderThanYear)
                         {
                             ShowroomCarObj.SetActive(false);
                             MelonLogger.Msg($"Car year {carYear}");

--- a/RealShop/RealShop.cs
+++ b/RealShop/RealShop.cs
@@ -1,48 +1,313 @@
 ﻿using MelonLoader;
+using Harmony;
 using UnityEngine;
 using UnityEngine.UI;
+using OrbCreationExtensions;
+using System.Collections.Generic;
+using System.Linq;
+using CMS.UI.Windows;
+using CMS.UI.Logic;
 using System;
+using CMS.Difficulty;
 
+
+// TODO:
+// сделать что бы все предметы могли ремонтироваться
+// сделать что с первого уровня доступны все станки для ремонта
+// посещение свалки с перого уровня и бесплатно
 namespace RealShop
 {
     public class RealParts : MelonMod
     {
-
         private Config _config;
+        private bool _modIsEnable = true;
+        private bool _runOnes = false;
+
+        GameObject _blocker_Repair_Parts_2;
+        GameObject _blocker_Repair_Parts_3;
 
         [Obsolete]
         public override void OnApplicationStart()
         {
             MelonLogger.Msg("initializing...");
+
             _config = new Config();
             _config.Reload();
         }
 
         public override void OnUpdate()
         {
+            if  (Input.GetKeyDown(_config.IsEnableSwitchMode))
+            {
+                if (_modIsEnable)
+                {
+                    _modIsEnable = false;
+                    UIManager.Get().ShowPopup("[RealShop]","has been stoped.", PopupType.GameMode);
+                } else {
+                    _modIsEnable = true;
+                    UIManager.Get().ShowPopup("[RealShop]", "has been enabled.", PopupType.GameMode);
+                }
+            }
+
+            if (Input.GetKeyDown(_config.Repair))
+            {
+                RepairItems(Config.TargetRepairParts, Config.RepairCost);
+            }
+
+            if (!_modIsEnable) {
+                return;
+            }
+
+            if (_runOnes)
+            {
+                GlobalPref();
+            }
+
+            RemoveBlocks();
+
+            GameObject engineRoom = GameObject.Find("EngineRoom");
+            if (engineRoom != null)
+            {
+                var erw = engineRoom.transform.Find("Engine_Room_Workbench_2");
+                if(erw != null)
+                {
+                    var gameobj = erw.gameObject;
+                    gameobj?.SetActive(true);
+                }
+
+                var erbt = engineRoom.transform.Find("Engine_Room_Big_Table");
+                if (erbt != null)
+                {
+                    var gameobj = erbt.gameObject;
+                    gameobj?.SetActive(true);
+                }
+
+            }
 
             GameObject shopCarWindow = GameObject.Find("ShopCarWindow");
             if (shopCarWindow != null)
             {
-                var itemsCars = shopCarWindow.transform.Find("Items");
-                if (itemsCars != null)
+                CheckAndDisableOldCarFromShop(shopCarWindow);
+
+                return;
+            }
+
+            GameObject shopMenu = GameObject.Find("ShopMenu");
+            if (shopMenu != null && _config.IsEnableBrandFilter)
+            {
+                CheckAndDisableBrandsFromShop(shopMenu);
+            }
+        }
+
+        private void RepairItems(string[] repairParts, int[] repairCost)
+        {
+            Inventory inventory = Singleton<Inventory>.Instance;
+            var cItems = inventory.GetItems();
+            foreach (var baseItem in cItems)
+            {
+                if (baseItem.Condition == 1.0f)
                 {
-                    for (int i = 0; i < itemsCars.childCount; i++)
+                    continue;
+                }
+
+                if (Helpers.CheckForSubstrings(baseItem.ID, repairParts))
+                {
+                    var money = GlobalData.PlayerMoney;
+                    var currentCond = baseItem.Condition;
+
+                    if (currentCond < 0.15f && money < repairCost[2])
                     {
-                        Transform ShowroomCarItem21Shop = itemsCars.GetChild(i);
-                        GameObject ShowroomCarObj = ShowroomCarItem21Shop.gameObject;
-                        var carName = ShowroomCarItem21Shop.Find("CarName").GetComponent<Text>();
-                        var carYear = Helpers.GetYearFromString(carName.text);
-                        if (carYear < _config.RemoveCarsOlderThanYear)
-                        {
-                            ShowroomCarObj.SetActive(false);
-                            MelonLogger.Msg($"Car year {carYear}");
-                        }
+                        UIManager.Get().ShowPopup(Config.ModName, "insufficient funds", PopupType.Normal);
+
+                        return;
                     }
 
+                    if (currentCond < 0.4f && money < repairCost[1])
+                    {
+                        UIManager.Get().ShowPopup(Config.ModName, "insufficient funds", PopupType.Normal);
+
+                        return;
+                    }
+
+                    if (currentCond < 0.7f && money < repairCost[0])
+                    {
+                        UIManager.Get().ShowPopup(Config.ModName, "insufficient funds", PopupType.Normal);
+
+                        return;
+                    }
+
+                    float finallyPrice = 0;
+
+                    switch (currentCond)
+                    {
+                        case var cond when cond < 0.15f:
+                            finallyPrice = repairCost[2] + (currentCond * repairCost[2]);
+                            GlobalData.AddPlayerMoney(-(int)finallyPrice);
+                            break;
+
+                        case var cond when cond < 0.4f:
+                            finallyPrice = repairCost[1] + (currentCond * repairCost[1]);
+                            GlobalData.AddPlayerMoney(-(int)finallyPrice);
+                            break;
+
+                        case var cond when cond < 0.7f:
+                            finallyPrice = repairCost[0] + (currentCond * repairCost[0]);
+                            GlobalData.AddPlayerMoney(-(int)finallyPrice);
+                            break;
+                    }
+
+                    baseItem.Condition = 1.0f;
+                    baseItem.Dent = 1.0f;
+
+                    UIManager.Get().ShowPopup(Config.ModName, $"item was repair! cost: {finallyPrice}", PopupType.Normal);
+                } else
+                {
+                    MelonLogger.Msg($"{Helpers.ToPrettyString(baseItem)}");
                 }
             }
         }
+
+        private void CheckAndDisableOldCarFromShop(GameObject shopCarWindow)
+        {
+
+            var itemsCars = shopCarWindow.transform.Find("Items");
+            if (itemsCars != null)
+            {
+
+                for (int i = 0; i < itemsCars.childCount; i++)
+                {
+                    Transform ShowroomCarItem21Shop = itemsCars.GetChild(i);
+                    var carName = ShowroomCarItem21Shop.Find("CarName").GetComponent<Text>();
+                    var carYear = Helpers.GetYearFromString(carName.text);
+
+                    if (carYear < _config.RemoveCarsOlderThanYear)
+                    {
+                        GameObject ShowroomCarObj = ShowroomCarItem21Shop.gameObject;
+                        ShowroomCarObj.SetActive(false);
+
+                        if (_config.IsShowDebugInfo)
+                        {
+                            MelonLogger.Msg($"car year {carYear}");
+                        }
+                    }
+                }
+            }
+        }
+
+        private void CheckAndDisableBrandsFromShop(GameObject shopMenu)
+        {
+
+/*            var mainLableText = shopMenu.transform.Find("MainLabel").GetComponent<Text>();
+            if (mainLableText != null) {
+                MelonLogger.Msg($"main label");
+            }*/
+
+            var items = shopMenu.transform.Find("Items");
+            if (items != null)
+            {
+                for (int i = 0; i < items.childCount; i++)
+                {
+                    Transform part = items.GetChild(i);
+                    if (part == null)
+                    {
+                        continue;
+                    }
+
+                    var partBrand = part.Find("Brand");
+                    if (partBrand != null)
+                    {
+                        var image = partBrand.GetComponent<Image>();
+                        string imageName = image.sprite.name;
+
+                        if (!Helpers.IsBrandExist(imageName))
+                        {
+                            GameObject ShowroomCarObj = part.gameObject;
+                            ShowroomCarObj.SetActive(false);
+                        }
+
+                        //if (Input.GetKeyDown(_config.PrintStack))
+                       // {
+                        //MelonLogger.Msg($"id {i} texture {imageName}");
+                       // }
+                    }
+                }
+            }
+        }
+
+        private void RemoveBlocks()
+        {
+            var engineRoomBlocker = GameObject.Find("EngineRoomBlocker");
+            engineRoomBlocker?.SetActive(false);
+
+            _blocker_Repair_Parts_2 = GameObject.Find("Blocker_Repair_Parts_2");
+            _blocker_Repair_Parts_2?.SetActive(false);
+
+            _blocker_Repair_Parts_3 = GameObject.Find("Blocker_Repair_Parts_3");
+            _blocker_Repair_Parts_3?.SetActive(false);
+        }
+
+        private void GlobalPref()
+        {
+            _runOnes = false;
+
+            var itemsMain = Singleton<GameInventory>.Instance.GetItems(ShopType.Main);
+            SetAllRepairs(itemsMain);
+
+            var itemsBody = Singleton<GameInventory>.Instance.GetItems(ShopType.Body);
+            foreach (var item in itemsBody)
+            {
+                item.RepairGroup = 6;
+            }
+
+            var itemsInterior = Singleton<GameInventory>.Instance.GetItems(ShopType.Interior);
+            foreach (var item in itemsInterior)
+            {
+                item.RepairGroup = 6;
+            }
+
+            var itemsTire = Singleton<GameInventory>.Instance.GetItems(ShopType.Tire);
+            SetAllRepairs(itemsTire);
+            var itemsLicensePlate = Singleton<GameInventory>.Instance.GetItems(ShopType.LicensePlate);
+            SetAllRepairs(itemsLicensePlate);
+            var itemsTuning = Singleton<GameInventory>.Instance.GetItems(ShopType.Tuning);
+            SetAllRepairs(itemsTuning);
+            var itemsBodyTuning = Singleton<GameInventory>.Instance.GetItems(ShopType.BodyTuning);
+            SetAllRepairs(itemsBodyTuning);
+            var itemsRims = Singleton<GameInventory>.Instance.GetItems(ShopType.Rims);
+            SetAllRepairs(itemsRims);
+            var itemsGearbox = Singleton<GameInventory>.Instance.GetItems(ShopType.Gearbox);
+            SetAllRepairs(itemsGearbox);
+            var itemsElectronics = Singleton<GameInventory>.Instance.GetItems(ShopType.Electronics);
+            SetAllRepairs(itemsElectronics);
+            var itemsAddons = Singleton<GameInventory>.Instance.GetItems(ShopType.Addons);
+            SetAllRepairs(itemsAddons);
+        }
+
+        private void SetAllRepairs(Il2CppSystem.Collections.Generic.List<PartProperty> items)
+        {
+            MelonLogger.Msg($"start set repair groups {items.Count}");
+            foreach (var item in items)
+            {
+                if (!Helpers.IsBrandExist(item.Brand))
+                {
+                    item.RepairGroup = 6;
+                }
+            }
+
+            MelonLogger.Msg($"finished repair groups");
+        }
+
+        public override void OnSceneWasLoaded(int buildIndex, string sceneName)
+        {
+            LoggerInstance.Msg($"Scene {sceneName} with build index {buildIndex} has been loaded!");
+            if (sceneName == "garage" && buildIndex == 10)
+            {
+                _runOnes = true;
+
+                MelonLogger.Msg($"GlobalData.Cost_TravelJunkyard = {GlobalData.Cost_TravelJunkyard} ");
+            }
+        }
+
     }
 }
 

--- a/RealShop/RealShop.csproj
+++ b/RealShop/RealShop.csproj
@@ -41,34 +41,46 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Assets\Il2CppDumper-net7\DummyDll\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Steam\steamapps\common\Car Mechanic Simulator 2021\MelonLoader\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Assets\Il2CppDumper-net7\DummyDll\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Steam\steamapps\common\Car Mechanic Simulator 2021\MelonLoader\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
-    <Reference Include="MelonLoader, Version=0.6.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Il2Cppmscorlib">
+      <HintPath>..\..\..\..\..\..\Steam\steamapps\common\Car Mechanic Simulator 2021\MelonLoader\Managed\Il2Cppmscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="MelonLoader">
       <HintPath>..\..\..\..\..\..\Steam\steamapps\common\Car Mechanic Simulator 2021\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\Assets\Il2CppDumper-net7\DummyDll\UnityEngine.dll</HintPath>
+    <Reference Include="UnhollowerBaseLib, Version=0.4.18.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Steam\steamapps\common\Car Mechanic Simulator 2021\MelonLoader\Managed\UnhollowerBaseLib.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Steam\steamapps\common\Car Mechanic Simulator 2021\MelonLoader\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Assets\Il2CppDumper-net7\DummyDll\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Steam\steamapps\common\Car Mechanic Simulator 2021\MelonLoader\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>..\Assets_\Il2CppDumper-net6\DummyDll\UnityEngine.InputLegacyModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputModule">
+      <HintPath>..\Assets_\Il2CppDumper-net6\DummyDll\UnityEngine.InputModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Assets\Il2CppDumper-net7\DummyDll\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Steam\steamapps\common\Car Mechanic Simulator 2021\MelonLoader\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/RealShop/RealShop.csproj
+++ b/RealShop/RealShop.csproj
@@ -72,6 +72,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config.cs" />
     <Compile Include="Inspect.cs" />
     <Compile Include="RealShop.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Features include:

- You will need to search for the necessary parts for old cars and restore them; it is no longer possible to buy new parts for retro or old cars.
- Now junkyards, barns, and auctions take on a different meaning.
- Now all body and interior parts can be repaired.
- Now you can repair generic parts from all non-default manufacturers.
- Added a configuration file where you can:
-            Change the year for cars that will not appear in the shop.
-            Change the binding key to enable or disable the mod.
-            Add or remove specific brands from the list that won't appear in the shop.